### PR TITLE
[zlib] Modify recipe -- internal branch

### DIFF
--- a/.jenkins/new_toolchains.jenkins
+++ b/.jenkins/new_toolchains.jenkins
@@ -36,7 +36,7 @@ WINDOWS_PROFILE = """\
     arch=x86_64
     compiler=Visual Studio
     compiler.runtime=MD
-    compiler.version=15
+    compiler.version=16
     build_type=Release
     [options]
     [build_requires]

--- a/.jenkins/new_toolchains.jenkins
+++ b/.jenkins/new_toolchains.jenkins
@@ -3,6 +3,7 @@ import org.yaml.snakeyaml.Yaml
 RAISE_HOOKS = true
 CONAN_BRANCH = 'develop'
 
+LINUX_CONTAINER = 'conanio/gcc10'
 LINUX_PROFILE = """\
     [settings]
     os=Linux
@@ -150,7 +151,7 @@ node('Linux') {
     stage('Parallel on platforms') {
         parallel(
             linux: {
-                docker.image('conanio/gcc10').inside {
+                docker.image(LINUX_CONTAINER).inside {
                     createReference([python_host: 'python3', 
                                      shFunction: { data -> sh(data) }, 
                                      isInsideDocker: true,

--- a/.jenkins/new_toolchains.jenkins
+++ b/.jenkins/new_toolchains.jenkins
@@ -90,7 +90,7 @@ def createReference(Map ctxt, List recipesToBuild) {
             stage("Create ${recipe.reference}") {
                 envInside(ctxt) {
                     // ctxt.shFunction("conan info ${recipe.folder} --profile=default")
-                    writeFile('pr_host', ctxt.profileHost)
+                    writeFile(file: 'pr_host', text: ctxt.profileHost)
                     ctxt.shFunction("conan create ${recipe.folder} ${recipe.reference}@ --profile=pr_host")
                 }
             }

--- a/recipes/zlib/1.2.11/conanfile.py
+++ b/recipes/zlib/1.2.11/conanfile.py
@@ -3,6 +3,7 @@ from conans import ConanFile, tools, CMake
 from conans.errors import ConanException
 
 
+# Modify recipe
 class ZlibConan(ConanFile):
     name = "zlib"
     version = "1.2.11"


### PR DESCRIPTION
We should use PRs, but please read here: https://github.com/tapia/conan-center-index/pull/2

Check job here: https://ci.conan.io/job/NewToolchains/job/mod%252Fzlib/

---

EDIT.- PRs are triggered for internal branches (see #4). Looks like they don't need @conanci extra permissions before running (they do to notify status)

---

Meanwhile (today), we can use branches in the repository, like the one I'm using here (`mod/zlib`) just for demo purposes, because they are being notified to Jenkins and there is no permissions issue if we want to modify the Jenkinsfile.

I've created here the PR to show the diff with `master`, but realize Jenkins is running the build of the branch, not the build of the PR (remember #2). 

This is the resulting pipeline:
![image](https://user-images.githubusercontent.com/1406456/129325309-5f67ee73-e15f-40f9-b458-74c6ed67db3a.png)

There are some differences with regular c3i behavior:
 * it will just build one profile for each major OS (enough to start)
 * it allows you to modify several recipes in the PR and it will run `conan create` for all of them in lexicographic order.
 * it will always build all the versions listed in the `config.yml` file
 * it doesn't handle `ConanInvalidConfiguration` exceptions